### PR TITLE
Update flags after recent kernel clean up

### DIFF
--- a/rtl8188ee/trx.c
+++ b/rtl8188ee/trx.c
@@ -444,10 +444,10 @@ bool rtl88ee_rx_query_desc(struct ieee80211_hw *hw,
 		rx_status->flag |= RX_FLAG_FAILED_FCS_CRC;
 
 	if (status->rx_is40Mhzpacket)
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 
 	if (status->is_ht)
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 

--- a/rtl8192ce/trx.c
+++ b/rtl8192ce/trx.c
@@ -369,10 +369,10 @@ bool rtl92ce_rx_query_desc(struct ieee80211_hw *hw,
 		rx_status->flag |= RX_FLAG_FAILED_FCS_CRC;
 
 	if (stats->rx_is40Mhzpacket)
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 
 	if (stats->is_ht)
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 

--- a/rtl8192cu/trx.c
+++ b/rtl8192cu/trx.c
@@ -329,9 +329,9 @@ bool rtl92cu_rx_query_desc(struct ieee80211_hw *hw,
 	if (!GET_RX_DESC_SWDEC(pdesc))
 		rx_status->flag |= RX_FLAG_DECRYPTED;
 	if (GET_RX_DESC_BW(pdesc))
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 	if (GET_RX_DESC_RX_HT(pdesc))
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 	if (stats->decrypted)
 		rx_status->flag |= RX_FLAG_DECRYPTED;
@@ -398,9 +398,9 @@ static void _rtl_rx_process(struct ieee80211_hw *hw, struct sk_buff *skb)
 	if (!GET_RX_DESC_SWDEC(rxdesc))
 		rx_status->flag |= RX_FLAG_DECRYPTED;
 	if (GET_RX_DESC_BW(rxdesc))
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 	if (GET_RX_DESC_RX_HT(rxdesc))
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 	/* Data rate */
 	rx_status->rate_idx = rtlwifi_rate_mapping(hw, stats.is_ht,
 						   false, stats.rate);

--- a/rtl8192de/trx.c
+++ b/rtl8192de/trx.c
@@ -503,9 +503,9 @@ bool rtl92de_rx_query_desc(struct ieee80211_hw *hw,	struct rtl_stats *stats,
 	if (!GET_RX_DESC_SWDEC(pdesc))
 		rx_status->flag |= RX_FLAG_DECRYPTED;
 	if (GET_RX_DESC_BW(pdesc))
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 	if (GET_RX_DESC_RXHT(pdesc))
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 	if (stats->decrypted)
 		rx_status->flag |= RX_FLAG_DECRYPTED;

--- a/rtl8192ee/trx.c
+++ b/rtl8192ee/trx.c
@@ -394,10 +394,10 @@ bool rtl92ee_rx_query_desc(struct ieee80211_hw *hw,
 		rx_status->flag |= RX_FLAG_FAILED_FCS_CRC;
 
 	if (status->rx_is40Mhzpacket)
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 
 	if (status->is_ht)
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 

--- a/rtl8192se/trx.c
+++ b/rtl8192se/trx.c
@@ -289,10 +289,10 @@ bool rtl92se_rx_query_desc(struct ieee80211_hw *hw, struct rtl_stats *stats,
 		rx_status->flag |= RX_FLAG_FAILED_FCS_CRC;
 
 	if (stats->rx_is40Mhzpacket)
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 
 	if (stats->is_ht)
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 

--- a/rtl8723ae/trx.c
+++ b/rtl8723ae/trx.c
@@ -317,10 +317,10 @@ bool rtl8723e_rx_query_desc(struct ieee80211_hw *hw,
 		rx_status->flag |= RX_FLAG_FAILED_FCS_CRC;
 
 	if (status->rx_is40Mhzpacket)
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 
 	if (status->is_ht)
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 

--- a/rtl8723be/trx.c
+++ b/rtl8723be/trx.c
@@ -373,10 +373,10 @@ bool rtl8723be_rx_query_desc(struct ieee80211_hw *hw,
 		rx_status->flag |= RX_FLAG_FAILED_FCS_CRC;
 
 	if (status->rx_is40Mhzpacket)
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 
 	if (status->is_ht)
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 

--- a/rtl8821ae/trx.c
+++ b/rtl8821ae/trx.c
@@ -520,18 +520,18 @@ bool rtl8821ae_rx_query_desc(struct ieee80211_hw *hw,
 		rx_status->flag |= RX_FLAG_FAILED_FCS_CRC;
 
 	if (status->rx_packet_bw == HT_CHANNEL_WIDTH_20_40)
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 	else if (status->rx_packet_bw == HT_CHANNEL_WIDTH_80)
-		rx_status->vht_flag |= RX_VHT_FLAG_80MHZ;
+		rx_status->bw |= RATE_INFO_BW_80;
 	if (status->is_ht)
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 	if (status->is_vht)
-		rx_status->flag |= RX_FLAG_VHT;
+		rx_status->encoding |= RX_ENC_VHT;
 
 	if (status->is_short_gi)
-		rx_status->flag |= RX_FLAG_SHORT_GI;
+		rx_status->enc_flags |= RX_ENC_FLAG_SHORT_GI;
 
-	rx_status->vht_nss = status->vht_nss;
+	rx_status->nss = status->vht_nss;
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 
 	/* hw will set status->decrypted true, if it finds the

--- a/rtl8822be/trx.c
+++ b/rtl8822be/trx.c
@@ -260,11 +260,11 @@ bool rtl8822be_rx_query_desc(struct ieee80211_hw *hw, struct rtl_stats *status,
 		rx_status->flag |= RX_FLAG_FAILED_FCS_CRC;
 
 	if (status->is_ht)
-		rx_status->flag |= RX_FLAG_HT;
+		rx_status->enc_flags |= RX_ENC_FLAG_HT_GF;
 	if (status->is_vht)
-		rx_status->flag |= RX_FLAG_VHT;
+		rx_status->encoding |= RX_ENC_VHT;
 
-	rx_status->vht_nss = status->vht_nss;
+	rx_status->nss = status->vht_nss;
 
 	rx_status->flag |= RX_FLAG_MACTIME_START;
 
@@ -308,9 +308,9 @@ bool rtl8822be_rx_query_desc(struct ieee80211_hw *hw, struct rtl_stats *status,
 	rx_status->signal = status->recvsignalpower;
 
 	if (status->rx_packet_bw == HT_CHANNEL_WIDTH_20_40)
-		rx_status->flag |= RX_FLAG_40MHZ;
+		rx_status->bw |= RATE_INFO_BW_40;
 	else if (status->rx_packet_bw == HT_CHANNEL_WIDTH_80)
-		rx_status->vht_flag |= RX_VHT_FLAG_80MHZ;
+		rx_status->bw |= RATE_INFO_BW_80;
 
 	return true;
 }


### PR DESCRIPTION
I've open this PR as a request for comments more than anything else. I have managed to get the code to compile with kernel 4.13 after updating various flags (RX, bandwidth, etc) best I could given the commits I saw in mainline [0], [1]. The code now compiles and the module installs cleanly on my laptop. However, take this with a grain of salt, given that:

- I don't know kernel code;
- I don't fully understand the clean-up done in mainline;
- I still cannot connect to wifi.

Its likely that this is not the best approach and even if it is, it may contain mistakes. In addition, I assume that, by applying this patch, the driver will no longer compile against kernels pre-clean-up. Presumably some kind of macros are required in order to support both pre and post-clean-up kernels.

With all of that said let, do me know if you have any comments on the patch. I personally am just trying to get wireless working on my laptop :-) In terms of the behaviour of the patch on my laptop:

- straight after I ```make install``` and reboot I can see wireless networks. However, I cannot connect. I see the following in the log:

```
[    2.817692] rtlwifi: loading out-of-tree module taints kernel.
[    2.884073] Bluetooth: hci0: rtl: examining hci_ver=07 hci_rev=000b lmp_ver=07 lmp_subver=8822
[    2.884076] Bluetooth: hci0: rtl: loading rtl_bt/rtl8822b_config.bin
[    2.885593] bluetooth hci0: firmware: direct-loading firmware rtl_bt/rtl8822b_config.bin
[    2.885603] Bluetooth: hci0: rtl: loading rtl_bt/rtl8822b_fw.bin
[    2.886897] bluetooth hci0: firmware: direct-loading firmware rtl_bt/rtl8822b_fw.bin
[    4.885108] rtl8822be: Using firmware rtlwifi/rtl8822befw.bin
[    4.887265] rtl8822be 0000:02:00.0: firmware: direct-loading firmware rtlwifi/rtl8822befw.bin
[    4.892998] ieee80211 phy0: Selected rate control algorithm 'rtl_rc'
[    4.893358] rtlwifi: rtlwifi: wireless switch is on
[    6.219067] rtl8822be 0000:02:00.0 wlo1: renamed from wlan0
[   10.320292] rtl8822be 0000:02:00.0: AMD-Vi: Event logged [IO_PAGE_FAULT domain=0x0001 address=0x00000000fef36c40 flags=0x0000]
[  135.007928] rtl8822be 0000:02:00.0: AMD-Vi: Event logged [IO_PAGE_FAULT domain=0x0001 address=0x00000000fef36c40 flags=0x0000]
```
- once I reboot a second time, I then stop being able to see networks at all. Subsequent reboots do not help. I then see a lot of errors in dmesg:

```
# dmesg | grep halmac
[    2.872361] halmac: HALMAC_MAJOR_VER_88XX = 1
[    2.872363] halmac: HALMAC_PROTOTYPE_88XX = 3
[    2.872363] halmac: HALMAC_MINOR_VER_88XX = 5
[    2.872364] halmac: HALMAC_PATCH_VER_88XX = 0
[    9.942081] halmac: halmac_check_fw_chksum_88xx error!!
[    9.943044] halmac: halmac_check_fw_chksum_88xx fail!!
[    9.943052] rtl8822be: halmac_init_hal failed
[    9.989879] rtl8822be: halmac_init_hal failed
[    9.990260] rtl8822be: halmac_init_hal failed
...
```
- if I do a new ```make install``` I get back to being able to see networks but unable to connect.

I am not sure if these issues are related to my changes; it seems similar issues have been reported elsewhere [2].

Cheers

Marco

[0] https://github.com/torvalds/linux/commit/7fdd69c5af2160236e97668bc1fb7d70855c66ae#diff-1075d6e37d6e772865460fdf6d143dd7
[1] https://github.com/torvalds/linux/commit/8613c94815fcdd358638a22fed50c3f172042aa2#diff-1075d6e37d6e772865460fdf6d143dd7
[2] https://ubuntuforums.org/showthread.php?t=2364383&page=2